### PR TITLE
Increase timeout

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -21,7 +21,7 @@ func Run(appConfigFile string) {
 		Addr:         fmt.Sprintf(":%d", appConfig.Server.Port),
 		Handler:      api(appConfig),
 		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		WriteTimeout: 30 * time.Second,
 	}
 	err := s.ListenAndServe()
 	if err != nil {

--- a/common/http/http.go
+++ b/common/http/http.go
@@ -42,7 +42,7 @@ func Request(method string, baseURL string, path string, data interface{}, respo
 
 	client := http.Client{
 		Transport: transport,
-		Timeout:   time.Duration(10 * time.Second),
+		Timeout:   time.Duration(30 * time.Second),
 	}
 
 	resp, err := client.Do(req)


### PR DESCRIPTION
To ensure GET /hosts don't timeout when IPMI take time to respond
for some hosts.