### PR TITLE
Rename operation "Discovery" to "Refresh"

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,19 +302,19 @@ Code   | Name          | Description
 `400`  | `Bad request` | Malformed body
 
 
-## Discover hosts over the network
+## Refresh hosts information
 
 This API populate the ARP table for all subnets in the PXE Pilot configuration
 
 ```
-PATCH /v1/discovery
+PATCH /v1/refresh
 ```
 
 ###### Response codes
 
 Code   | Name          | Description
 -------|---------------|---------------------------------------------------
-`204`  | `No Content`  | Discovery operation completed without any issue
+`204`  | `No Content`  | Refresh operation completed without any issue
 
 
 # License

--- a/api/api.go
+++ b/api/api.go
@@ -60,7 +60,7 @@ func api(appConfig *model.AppConfig) *gin.Engine {
 	readHosts(v1, appConfig)
 	rebootHost(v1, appConfig)
 
-	discovery(v1, appConfig)
+	refresh(v1, appConfig)
 
 	return api
 }

--- a/api/hosts.go
+++ b/api/hosts.go
@@ -29,10 +29,10 @@ func rebootHost(api *gin.RouterGroup, appConfig *model.AppConfig) {
 	})
 }
 
-func discovery(api *gin.RouterGroup, appConfig *model.AppConfig) {
-	api.PATCH("/discovery", func(c *gin.Context) {
+func refresh(api *gin.RouterGroup, appConfig *model.AppConfig) {
+	api.PATCH("/refresh", func(c *gin.Context) {
 
-		if service.Discovery(appConfig) != nil {
+		if service.Refresh(appConfig) != nil {
 			c.Writer.WriteHeader(500)
 		}
 

--- a/cli.go
+++ b/cli.go
@@ -175,14 +175,14 @@ func setupCLI() {
 				}
 			}
 		})
-		cmd.Command("discovery", "Discover hosts over subnets", func(cmd *cli.Cmd) {
+		cmd.Command("refresh", "Refresh hosts information", func(cmd *cli.Cmd) {
 			cmd.Action = func() {
 				logger.Init(!*debug)
-				statusCode, err := http.Request("PATCH", *serverURL, "/v1/discovery", nil, nil)
+				statusCode, err := http.Request("PATCH", *serverURL, "/v1/refresh", nil, nil)
 
 				// Print data table
 				table := tablewriter.NewWriter(os.Stdout)
-				table.SetHeader([]string{"Discovery"})
+				table.SetHeader([]string{"Refresh"})
 				table.SetAutoWrapText(false)
 				if err != nil {
 					table.Append([]string{"ERROR : " + err.Error()})

--- a/service/service.go
+++ b/service/service.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ggiamarchi/pxe-pilot/model"
 )
 
-func Discovery(appConfig *model.AppConfig) error {
+func Refresh(appConfig *model.AppConfig) error {
 
 	hosts := ReadHosts(appConfig, false)
 


### PR DESCRIPTION
This operation was not really named well. It is actually only
refreshing IP information for host already registered in
PXE Pilot. It does not discover new hosts.